### PR TITLE
Fix staging failure after staging.stop message

### DIFF
--- a/src/CloudFoundry.WinDEA/StagingInstance.cs
+++ b/src/CloudFoundry.WinDEA/StagingInstance.cs
@@ -71,6 +71,8 @@ namespace CloudFoundry.WinDEA
         public event StagingTaskEventHandler AfterUpload;
         public event StagingTaskEventHandler AfterStop;
 
+        public bool StopRequested { get; set; }
+
         public void SetupStagingEnvironment()
         {
             try


### PR DESCRIPTION
AfterStagingFinished does not need to run if a staging stop message is received.
This causes a problem when there is a 2nd staging request received by the DEA, while the first one is still running. 
The first staging would fail and notify the cloud controller that staging is failed while the 2nd staging process is running. 
This would cause the app to be in an error state, even though the 2nd staging is successful.