### PR TITLE
Add admin buildpacks support

### DIFF
--- a/src/CloudFoundry.WinDEA/Agent.cs
+++ b/src/CloudFoundry.WinDEA/Agent.cs
@@ -165,6 +165,7 @@
         private string directoryServerHmacKey;
         private string gitPath;
         private string buildpacksDir;
+        private string adminBuildpacksDir;
         private int stagingTimeoutMs;
         private string logyardUidPath;
         public string ExternalHost { get; set; }
@@ -245,6 +246,7 @@
 
             this.gitPath = cfSection.DEA.Staging.GitExecutable;
             this.buildpacksDir = cfSection.DEA.Staging.BuildpacksDirectory;
+            this.adminBuildpacksDir = Path.Combine(this.fileResources.DropletDir, "admin_buildpacks");
             this.stagingTimeoutMs = cfSection.DEA.Staging.StagingTimeoutMs;
         }
 
@@ -1414,7 +1416,7 @@
                     instance.Container.User.SetUserEnvironmentVariables(stagingEnvVars);
                 }
 
-                instance.GetBuildpack(pmessage, this.gitPath, this.buildpacksDir);
+                instance.GetBuildpack(pmessage, this.gitPath, this.buildpacksDir, this.adminBuildpacksDir);
                 this.stagingTaskRegistry.ScheduleSnapshotStagingState();
 
                 try
@@ -1553,7 +1555,7 @@
                         Logger.Debug("Staging task {0}: Packing droplet {1}", instance.Properties.TaskId, instance.Workspace.StagedDropletPath);
                         Directory.CreateDirectory(instance.Workspace.StagedDropletDir);
 
-                        DEAUtilities.CreateArchive(instance.Workspace.StagedDir, instance.Workspace.StagedDropletPath, false);
+                        DEAUtilities.CreateArchive(instance.Workspace.StagedDir, instance.Workspace.StagedDropletPath, true);
 
                         if (File.Exists(instance.Workspace.StagedDropletPath))
                         {
@@ -1580,7 +1582,7 @@
                     {
                         Directory.CreateDirectory(instance.Workspace.Cache);
 
-                        DEAUtilities.CreateArchive(instance.Workspace.Cache, instance.Workspace.StagedBuildpackCachePath, false);
+                        DEAUtilities.CreateArchive(instance.Workspace.Cache, instance.Workspace.StagedBuildpackCachePath, true);
                         Uri uri = new Uri(instance.Properties.BuildpackCacheUploadURI);
                         Logger.Debug("Staging task {0}: Uploading buildpack cache {1} to {2}", instance.Properties.TaskId, instance.Workspace.StagedBuildpackCachePath, instance.Properties.BuildpackCacheUploadURI);
                         DEAUtilities.HttpUploadFile(instance.Properties.BuildpackCacheUploadURI, new FileInfo(instance.Workspace.StagedBuildpackCachePath), "upload[droplet]", "application/octet-stream", uri.UserInfo);

--- a/src/CloudFoundry.WinDEA/CloudFoundry.WinDEA.csproj
+++ b/src/CloudFoundry.WinDEA/CloudFoundry.WinDEA.csproj
@@ -83,6 +83,7 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Transactions">
       <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Transactions.dll</HintPath>
     </Reference>

--- a/src/CloudFoundry.WinDEA/Messages/StagingStartMessageRequest.cs
+++ b/src/CloudFoundry.WinDEA/Messages/StagingStartMessageRequest.cs
@@ -35,11 +35,25 @@
 
         [JsonName("start_message")]
         public DeaStartMessageRequest StartMessage { get; set; }
+
+        [JsonName("admin_buildpacks")]
+        public StagingStartRequestAdminBuildpack[] AdminBuildpacks { get; set; }
     }
 
     class StagingStopMessageRequest : JsonConvertibleObject
     {
         [JsonName("app_id")]
         public string AppID { get; set; }
+    }
+
+
+    // Ref: https://github.com/cloudfoundry/dea_ng/blob/082c6cbf5c308c35b066034115b7c37b881d2aa1/lib/dea/staging/buildpacks_message.rb
+    public class StagingStartRequestAdminBuildpack : JsonConvertibleObject
+    {
+        [JsonName("key")]
+        public string Key { get; set; }
+
+        [JsonName("url")]
+        public string Url { get; set; }
     }
 }

--- a/src/CloudFoundry.WinDEA/Messages/StagingStartRequestProperties.cs
+++ b/src/CloudFoundry.WinDEA/Messages/StagingStartRequestProperties.cs
@@ -21,6 +21,12 @@
         [JsonName("buildpack")]
         public string Buildpack { get; set; }
 
+        [JsonName("buildpack_git_url")]
+        public string BuildpackGitUrl { get; set; }
+
+        [JsonName("buildpack_key")]
+        public string BuildpackKey { get; set; }
+
         [JsonName("resources")]
         public StagingStartRequestResources Resources { get; set; }
 

--- a/src/CloudFoundry.WinDEA/StagingInstance.cs
+++ b/src/CloudFoundry.WinDEA/StagingInstance.cs
@@ -11,11 +11,16 @@ using System.Text;
 using System.Threading;
 using CloudFoundry.WinDEA.Messages;
 using CloudFoundry.Utilities;
+using System.IO.Compression;
 
 namespace CloudFoundry.WinDEA
 {
     public class StagingInstance : IDisposable
     {
+        private static string[] buildpackBinaries = new string[] { "detect", "compile", "release" };
+
+        private static string[] binariesExtensions = new string[] { ".COM", ".EXE", ".BAT", ".CMD" };
+
         /// <summary>
         /// The lock for the staging instance.
         /// </summary>
@@ -242,10 +247,11 @@ namespace CloudFoundry.WinDEA
             }
         }
 
-        public void GetBuildpack(StagingStartMessageRequest message, string gitPath, string buildpacksDir)
+        public void GetBuildpack(StagingStartMessageRequest message, string gitPath, string buildpacksDir, string adminBuildpackDir)
         {
+            string buildpackUrl = message.Properties.Buildpack ?? message.Properties.BuildpackGitUrl;
 
-            if (message.Properties.Buildpack != null)
+            if (buildpackUrl != null)
             {
                 Logger.Info("Staging task {0}: Downloading buildpack from {1}", this.Properties.TaskId, message.Properties.Buildpack);
                 Directory.CreateDirectory(Path.Combine(this.Workspace.TempDir, "buildpacks"));
@@ -265,32 +271,154 @@ namespace CloudFoundry.WinDEA
                     throw new Exception("Buildpack does not support this application.");
                 }
             }
+            else if (message.Properties.BuildpackKey != null)
+            {
+                Logger.Info("Staging task {0}: Using admin buildpack {1}", this.Properties.TaskId, message.Properties.BuildpackKey);
+
+                TryCleanupUnusedAdminBuildpacks(message.AdminBuildpacks, adminBuildpackDir);
+                var adminBuildpack = message.AdminBuildpacks.First(i => i.Key == message.Properties.BuildpackKey);
+
+                InitializeAdminBuildpack(adminBuildpack, adminBuildpackDir, false);
+
+                this.Buildpack = new Buildpack(Path.Combine(this.Workspace.TempDir, "buildpack"), Path.Combine(this.Workspace.StagedDir, "app"), this.Workspace.Cache, this.Workspace.StagingLogPath);
+
+                bool detected = this.Buildpack.Detect(this.Container);
+                if (!detected)
+                {
+                    throw new InvalidOperationException("Buildpack does not support this application.");
+                }
+            }
             else
             {
                 Logger.Info("Staging task {0}: Detecting buildpack", this.Properties.TaskId);
-                foreach (string dir in Directory.EnumerateDirectories(buildpacksDir))
+
+                List<string> systemBuildpacks = Directory.EnumerateDirectories(buildpacksDir).ToList();
+
+                if (message.AdminBuildpacks != null)
                 {
-                    DEAUtilities.DirectoryCopy(dir, Path.Combine(this.Workspace.TempDir, "buildpack"), true);
-                    Buildpack bp = new Buildpack(Path.Combine(this.Workspace.TempDir, "buildpack"), Path.Combine(this.Workspace.StagedDir, "app"), this.Workspace.Cache, this.Workspace.StagingLogPath);
-                    bool success = bp.Detect(this.Container);
-                    if (success)
+                    TryCleanupUnusedAdminBuildpacks(message.AdminBuildpacks, adminBuildpackDir);
+
+                    foreach (var adminBuildpack in message.AdminBuildpacks)
                     {
-                        this.Buildpack = bp;
-                        break;
-                    }
-                    else
-                    {
-                        Directory.Delete(Path.Combine(this.Workspace.TempDir, "buildpack"), true);
+                        if (!InitializeAdminBuildpack(adminBuildpack, adminBuildpackDir, true))
+                        {
+                            continue;
+                        }
+
+                        Buildpack bp = new Buildpack(Path.Combine(this.Workspace.TempDir, "buildpack"), Path.Combine(this.Workspace.StagedDir, "app"), this.Workspace.Cache, this.Workspace.StagingLogPath);
+                        bool success = bp.Detect(this.Container);
+                        if (success)
+                        {
+                            this.Buildpack = bp;
+                            break;
+                        }
+                        else
+                        {
+                            Directory.Delete(Path.Combine(this.Workspace.TempDir, "buildpack"), true);
+                        }
                     }
                 }
 
                 if (this.Buildpack == null)
                 {
-                    throw new Exception("Unable to detect a supported application type");
+                    foreach (string dir in systemBuildpacks)
+                    {
+                        DEAUtilities.DirectoryCopy(dir, Path.Combine(this.Workspace.TempDir, "buildpack"), true);
+                        Buildpack bp = new Buildpack(Path.Combine(this.Workspace.TempDir, "buildpack"), Path.Combine(this.Workspace.StagedDir, "app"), this.Workspace.Cache, this.Workspace.StagingLogPath);
+                        bool success = bp.Detect(this.Container);
+                        if (success)
+                        {
+                            this.Buildpack = bp;
+                            break;
+                        }
+                        else
+                        {
+                            Directory.Delete(Path.Combine(this.Workspace.TempDir, "buildpack"), true);
+                        }
+                    }
+                }
+
+                if (this.Buildpack == null)
+                {
+                    throw new InvalidOperationException("Unable to detect a supported application type.");
                 }
                 Logger.Info("Staging task {0}: Detected buildpack {1}", this.Properties.TaskId, this.Buildpack.Name);
             }
+
             this.Properties.DetectedBuildpack = this.Buildpack.Name;
+        }
+
+        public bool InitializeAdminBuildpack(StagingStartRequestAdminBuildpack adminBuildpack, string adminBuildpackDir, bool checkWindowsCompatibility)
+        {
+            var dir = Path.Combine(adminBuildpackDir, adminBuildpack.Key);
+            var buildpackMutex = new Mutex(false, AdminBuildpackMutexName(adminBuildpack.Key));
+
+            try
+            {
+                buildpackMutex.WaitOne();
+
+                DownloadAdminBuildpack(adminBuildpack, adminBuildpackDir);
+
+                if (checkWindowsCompatibility)
+                {
+                    var winBuildpack = BuildpackHasWindowsCompatibleBinaries(dir);
+                    if (!winBuildpack)
+                    {
+                        Logger.Info("Ignoring buildpack {1}. Staging task {0}. Unable to detect compatible windows executables in buildpack bin.", this.Properties.TaskId, dir);
+                        return false;
+                    }
+                }
+
+                DEAUtilities.DirectoryCopy(dir, Path.Combine(this.Workspace.TempDir, "buildpack"), true);
+            }
+
+            finally
+            {
+                buildpackMutex.ReleaseMutex();
+                buildpackMutex.Dispose();
+            }
+
+            return true;
+        }
+
+        public void DownloadAdminBuildpack(StagingStartRequestAdminBuildpack adminBuildpack, string adminBuildpackDir)
+        {
+            string archiveFile = Path.Combine(adminBuildpackDir, adminBuildpack.Key + ".zip");
+            string destDir = Path.Combine(adminBuildpackDir, adminBuildpack.Key);
+
+            if (Directory.Exists(destDir))
+            {
+                Logger.Info("Skipping download for admin buildpack {0} because it was previously downloaded in {1}", adminBuildpack.Key, destDir);
+                return;
+            }
+
+            Directory.CreateDirectory(destDir);
+
+            WebClient client = new WebClient();
+
+            try
+            {
+                Logger.Info("Downloading admin buildpack {0} in {1} from {2}", adminBuildpack.Key, destDir, adminBuildpack.Url);
+
+                var downloadUri = new Uri(adminBuildpack.Url);
+                client.Headers[HttpRequestHeader.Authorization] = "Basic " + System.Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(downloadUri.UserInfo));
+                client.DownloadFile(downloadUri, archiveFile);
+
+                ZipFile.ExtractToDirectory(archiveFile, destDir);
+            }
+            catch
+            {
+                Directory.Delete(destDir, true);
+                File.Delete(archiveFile);
+
+                throw;
+            }
+            finally
+            {
+                client.Dispose();
+            }
+
+            File.Delete(archiveFile);
         }
 
         public string GetStartCommand()
@@ -346,6 +474,75 @@ namespace CloudFoundry.WinDEA
                 if (this.readerWriterLock != null)
                 {
                     this.readerWriterLock.Dispose();
+                }
+            }
+        }
+
+        private static bool BuildpackHasWindowsCompatibleBinaries(string buildpackDir)
+        {
+            foreach (var app in buildpackBinaries)
+            {
+                bool found = false;
+                foreach (string ext in binariesExtensions)
+                {
+                    if (File.Exists(Path.Combine(buildpackDir, "bin", app + ext)))
+                    {
+                        found = true;
+                    }
+                }
+                if (!found)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static string AdminBuildpackMutexName(string key)
+        {
+            return "admin-buildpack-" + key;
+        }
+
+        private void TryCleanupUnusedAdminBuildpacks(StagingStartRequestAdminBuildpack[] adminBuildpacks, string adminBuildpackDir)
+        {
+            if (!Directory.Exists(adminBuildpackDir))
+            {
+                return;
+            }
+
+            var cachedAdminBuilpacks = new DirectoryInfo(adminBuildpackDir).EnumerateDirectories().ToDictionary(di => di.Name, di => di.FullName);
+
+            var adminBuildpacksLookup = adminBuildpacks.ToLookup(ab => ab.Key);
+
+            foreach (var cachedBuildpack in cachedAdminBuilpacks)
+            {
+                if (adminBuildpacksLookup.Contains(cachedBuildpack.Key))
+                {
+                    continue;
+                }
+
+                bool signaled = false;
+                var buildpackMutex = new Mutex(false, AdminBuildpackMutexName(cachedBuildpack.Key));
+
+                try
+                {
+                    signaled = buildpackMutex.WaitOne(0);
+
+                    if (signaled)
+                    {
+                        Logger.Info("Deleting old admin buildpack {0} from {1}", cachedBuildpack.Key, cachedBuildpack.Value);
+
+                        Directory.Delete(cachedBuildpack.Value, true);
+                    }
+                }
+                finally
+                {
+                    if (signaled)
+                    {
+                        buildpackMutex.ReleaseMutex();
+                    }
+
+                    buildpackMutex.Dispose();
                 }
             }
         }


### PR DESCRIPTION
This PR adds support for buildpacks that come form cloud_controller at staging time.
System buildpacks (i.e. backpacks that are tied with the DEA installation) are still supported, but admin buildpacks will have precedence over system buildpacks.

Because there is no relationship between buildpacks and stacks, admin buildpacks will be ignored if they do not contain windows runnables (e.g. exe, bat, ps1) in the bin folder.

@viovanov  @mihaibuzgau @florindragos   can you please review this