### PR TITLE
Fix cleanup for staing tasks and dealock

### DIFF
--- a/src/CloudFoundry.WinDEA/Agent.cs
+++ b/src/CloudFoundry.WinDEA/Agent.cs
@@ -2446,9 +2446,11 @@
                                 instance.Container.JobObject.TerminateProcesses(-1);
                             }
                             catch { }
-                            instance.Properties.CleanupInstance = true;
+
                             instance.CompileProcess = null;
                         }
+
+                        instance.Properties.CleanupInstance = true;
                         instance.Properties.StagingDone = true;
                     }
 

--- a/src/CloudFoundry.WinDEA/Agent.cs
+++ b/src/CloudFoundry.WinDEA/Agent.cs
@@ -1879,7 +1879,6 @@
                                         instance.Properties.State = DropletInstanceState.Running;
                                         instance.Properties.StateTimestamp = DateTime.Now;
 
-                                        this.SendHeartbeat();
                                         this.RegisterInstanceWithRouter(instance);
                                         this.droplets.ScheduleSnapshotAppState();
                                     }
@@ -1893,6 +1892,11 @@
                             finally
                             {
                                 instance.Lock.ExitWriteLock();
+                            }
+
+                            if (detected)
+                            {
+                                this.SendHeartbeat();
                             }
                         });
                 });


### PR DESCRIPTION
There are some situations when the staging task will not get cleanup. An example is when the git clone for the buildpack fails. When enough tasks are leaked the CC will see the DEA as full and not schedule any new task on that DEA. 
Debugged this issue with @florindragos 

Please don't merge this yet.